### PR TITLE
Reformat parameters to work with new templater

### DIFF
--- a/dojocli/cli.py
+++ b/dojocli/cli.py
@@ -10,7 +10,7 @@ from dojocli.dojo_client import DojoClient
 import json
 
 
-def print_description(model_dict: dict):
+def print_description(model_dict: dict, param_dicts: dict):
     """
     Description
     -----------
@@ -42,8 +42,8 @@ def print_description(model_dict: dict):
     click.echo(f'DOCKER IMAGE\n------------\n{model_dict["image"]}\n')
 
     click.echo('PARAMETERS\n----------')
-    for param_dict in model_dict["parameters"]:
-        click.echo(param_dict["display_name"])
+    for param_dict in param_dicts:
+        click.echo(param_dict["annotation"]["name"])
 
     click.echo()
 
@@ -212,12 +212,13 @@ def describe(model, version, config):
 
     dc = DojoClient(config)
     model_dict = dc.get_model_info(model, version)
+    param_dicts = dc.get_parameters(model_dict["id"])
 
     if (model_dict == None):
         click.echo(f"\n No meta data is available for this model.\n")
         return
 
-    print_description(model_dict)
+    print_description(model_dict, param_dicts)
 
 
 @cli.command()
@@ -306,7 +307,7 @@ def runmodel(model, config, paramsfile, params, outputdir: str = None, version: 
         # If --params json is not passed, then --paramsfile, or the default --paramsfile, must exist.
         # Try opening the file before running the model.
         if not exists(paramsfile):
-            click.echo("\n--paramfile not found and --params is blank.\nOne of either --paramfile or --params is required.\n")
+            click.echo("\n--paramsfile not found and --params is blank.\nOne of either --paramsfile or --params is required.\n")
             return
 
     dc = DojoClient(config)

--- a/dojocli/dojo_client.py
+++ b/dojocli/dojo_client.py
@@ -10,11 +10,12 @@ from docker.api.volume import VolumeApiMixin
 
 # from requests.models import stream_decode_response_unicode
 from dojocli.docker_client import DockerClient
-from jinja2 import Template
+from subprocess import Popen, PIPE, run
 import json
 import os
 import re
 import requests
+import tarfile
 
 
 class DojoClient(object):
@@ -31,6 +32,7 @@ class DojoClient(object):
             else:
                 click.echo(e)
 
+
     def get_accessories(self, model_id: str):
         """
         Description
@@ -44,6 +46,7 @@ class DojoClient(object):
         """
 
         return self.get_dojo_stuff("accessories", model_id)
+
 
     def get_available_models(self):
         """
@@ -80,6 +83,7 @@ class DojoClient(object):
                 click.echo(response.text)
             exit
 
+
     def get_dojo_stuff(self, stuff, model_id):
         """
         Get stuff(config, directive, accessories, outputfiles) based on model_id.
@@ -95,6 +99,7 @@ class DojoClient(object):
             else:
                 click.echo(e)
             exit
+
 
     def get_metadata(self, model_id: str):
         """
@@ -129,6 +134,7 @@ class DojoClient(object):
             metadata[stuff] = self.get_dojo_stuff(stuff, model_id)
 
         return metadata
+
 
     def get_model_info(self, model_name: str, model_id: str = None):
         """
@@ -180,6 +186,26 @@ class DojoClient(object):
                 click.echo(e)
             exit
 
+
+    def get_parameters(self, model_id: str):
+        """
+        TODO
+        """
+        url = f'{self.dojo_url}/dojo/parameters/{model_id}'
+        try:
+            response = self.generic_dojo_get_request(url)
+            return response.json()
+
+        except Exception as e:
+            if hasattr(e, "message"):
+                click.echo(e.message)
+            else:
+                click.echo(e)
+            exit
+
+
+
+
     def get_model_versions_with_images(self, model_name: str):
         """
         Description
@@ -218,6 +244,7 @@ class DojoClient(object):
                 click.echo(e)
             exit
 
+
     def get_outputfiles(self, model_id: str):
         """
         Description
@@ -231,6 +258,7 @@ class DojoClient(object):
         """
 
         return self.get_dojo_stuff("outputfile", model_id)
+
 
     def get_results(self, id: str, name: str):
         """
@@ -250,9 +278,9 @@ class DojoClient(object):
                 The container name.
         """
         # Instantiate the Docker Client.
-        dc = DockerClient()
+        dockerc = DockerClient()
 
-        is_running = dc.is_running(container_id=id, container_name=name)
+        is_running = dockerc.is_running(container_id=id, container_name=name)
         if is_running is None:
             return
         if is_running:
@@ -291,6 +319,47 @@ class DojoClient(object):
 
             # Clean up.
             os.system(f"rm {os.getcwd()}/runs/local_output_folder.txt")
+
+
+    # TODO: Make this a more generalized function so it can be used with outputfiles
+    def get_config_content(
+         self,
+         image_name: str,
+         path: str,
+    ):
+        """
+        Description
+        -----------
+            Grabs the content
+
+        Parameters
+        ----------
+            image_name: str
+                The name of the image to generate the docker container
+            path: str
+                The path where the config file is located
+
+        Returns
+        ----------
+            Content of the file as a string.
+        """
+
+        # The docker commands will take either id or name.
+        dockerc = DockerClient()
+
+        # Create a container where we can extract by directly using docker lib
+        container = dockerc.api_client.create_container(
+            image_name, 
+            detach=False
+        )
+
+        with tarfile.open(fileobj=container.get_archive(path)[0], mode="r|") as file:
+            content = file.read().decode()
+
+        # Cleanup container.
+        container.remove(force=True)
+        return content
+
 
     def get_versions(self, model_name: str):
         """
@@ -485,21 +554,29 @@ class DojoClient(object):
             # If params was passed in the command line it is a str; convert to dict.
             params = json.loads(params)
 
+
+        def replace_along_params(string, new_values, available_parameters):
+            # Assuming no overlap
+            for param in sorted(available_parameters, key = lambda param: param['start'], reverse=True):
+                name = param["annotation"]["name"]
+                value = new_values[name] if name in new_values else param["annotation"]["default_value"]
+                string = string[:param["start"]] + str(value) + string[param["end"]:]
+            return string
+
+
         # get config files and hydrate them
         config_dict = {}
-        for configFile in metadata["config"]:
+        for config_file in metadata["config"]:
             try:
-                s3_url = configFile["s3_url"]
-                response = requests.get(s3_url)
-                config_file_template = Template(response.text)
-                config_rehydrated = config_file_template.render(params)
+                config_content = self.get_config_content(image_name, config_file["path"])
+                config_rehydrated = replace_along_params(config_content, params, config_file["parameters"])
                 if not os.path.isdir("temp"):
                     os.mkdir("temp")
 
                 temp_file_name = (
-                    os.getcwd() + "/temp/temp_" + configFile["path"].split("/")[-1]
+                    os.getcwd() + "/temp/temp_" + config_file["path"].split("/")[-1]
                 )
-                config_dict.update({temp_file_name: configFile["path"]})
+                config_dict.update({temp_file_name: config_file["path"]})
                 with open(temp_file_name, "w") as f:
                     f.write(config_rehydrated)
 
@@ -516,15 +593,14 @@ class DojoClient(object):
                 json.dump(accessory_captions, fh, indent=4)
 
         # Instantiate the Docker Client.
-        dc = DockerClient()
+        dockerc = DockerClient()
 
         # Pull the image
         click.echo(f"Getting model image ...\n")
-        dc.pull_image(image_name)
+        dockerc.pull_image(image_name)
 
         # Set run command from metadata["directive"]["command"] and substitute params.
-        model_command = Template(metadata["directive"]["command"])
-        model_command = model_command.render(params)
+        model_command = replace_along_params(metadata["directive"]["command"], params, metadata["directive"]["parameters"])
 
         # Create the container name.
         if model_name is None:
@@ -542,10 +618,10 @@ class DojoClient(object):
             )
 
             # Run the container attached.
-            dc.create_container(image_name, container_name, model_command, config_dict)
+            dockerc.create_container(image_name, container_name, model_command, config_dict)
 
             # account for wildcard output files
-            wildcard_outputs = dc.match_pattern_output_path(
+            wildcard_outputs = dockerc.match_pattern_output_path(
                 container_name, output_paths
             )
 
@@ -565,7 +641,7 @@ class DojoClient(object):
             )
 
             # Run the container detached.
-            container = dc.create_container(
+            container = dockerc.create_container(
                 image_name,
                 container_name,
                 model_command,
@@ -574,7 +650,7 @@ class DojoClient(object):
             )
 
             # Write the output folder path to the container or we won't know it.
-            dc.execute_command(
+            dockerc.execute_command(
                 f"bash -c 'printf \"{local_output_folder}\" > /home/clouseau/local_output_folder.txt'"
             )
 


### PR DESCRIPTION
[Shortrip](https://github.com/jataware/dojo/pull/188) makes breaking changes to the format. This PR patches `dojo-cli` to handle the switch.